### PR TITLE
Fix Pusher when using non-default cluster

### DIFF
--- a/src/Commands/PostChatHandler.php
+++ b/src/Commands/PostChatHandler.php
@@ -113,7 +113,8 @@ class PostChatHandler
         return new Pusher(
             $this->settings->get('flarum-pusher.app_key'),
             $this->settings->get('flarum-pusher.app_secret'),
-            $this->settings->get('flarum-pusher.app_id')
+            $this->settings->get('flarum-pusher.app_id'),
+            ['cluster' => $this->settings->get('flarum-pusher.app_cluster')]
         );
     }
 }


### PR DESCRIPTION
The cluster option was not passed to the library. It worked for most users since when Pusher library is supplied empty cluster option, it uses US by default.

Closes: #27